### PR TITLE
Change the comm_tbs_mac pilot key to be consistent. 

### DIFF
--- a/fpvscores/fpvscores.py
+++ b/fpvscores/fpvscores.py
@@ -70,8 +70,9 @@ class FPVScores():
         fields.register_pilot_attribute( UIField('safetycheck', "Safety Checked", UIFieldType.CHECKBOX) )
         fields.register_pilot_attribute( UIField('fpvs_uuid', "FPVS Pilot UUID", UIFieldType.TEXT) )
         fields.register_pilot_attribute( UIField('comm_elrs', "ELRS Passphrase", UIFieldType.TEXT) )
-        fields.register_pilot_attribute( UIField('comm_fusion', "Fusion Mac", UIFieldType.TEXT) )
-        
+        fields.register_pilot_attribute( UIField('comm_tbs_mac', "Fusion MAC Address", UIFieldType.TEXT) )
+    
+
         #ui.register_quickbutton("fpvscores_sync", "fpvscores_downloadavatars", "Download Pilot Avatars", self.runDownloadAvatarsBtn, {'rhapi': self._rhapi})
 
     def isConnected(self):


### PR DESCRIPTION
This pull request updates the pilot key for the TBS Fusion plugin to align with the key used in [RotorHazard/VRxC-Fusion](https://github.com/RotorHazard/VRxC-Fusion).

Currently, the interface presents two fields for TBS Fusion MAC addresses, which can be confusing. If the MAC address is entered in the wrong field, the plugin fails to send TBS Fusion messages because it looks for the MAC address under a mismatched key. This often leads to users needing to populate both fields to ensure functionality.

By standardizing the key to match the one in the VRxC-Fusion repository, this pull request removes the redundancy and simplifies the interface, requiring users to populate only one MAC address field.

closes FPVScores/FPVScores-Sync#49